### PR TITLE
Add IRC (#lilbee) setup: soju bouncer + Limnoria bot + helpers

### DIFF
--- a/irc/MANAGING.md
+++ b/irc/MANAGING.md
@@ -1,0 +1,121 @@
+# Managing soju
+
+## What it is / how it works
+
+soju is an **IRC bouncer**: a long-running process on the always-on box that stays
+connected to Libera 24/7 as your nick, so you never miss `#lilbee` traffic. Your weechat
+connects to *soju* (not Libera directly); soju relays both ways and replays backlog.
+
+**It is NOT dockerized.** It's a native package running under **systemd** (`soju.service`).
+Only the website (https-portal + tracker) runs in Docker.
+
+Layout on the box:
+
+```
+process : systemd unit  soju.service        (/usr/lib/systemd/system/soju.service)
+binary  : /usr/bin/soju  (+ sojuctl, sojudb)
+config  : /etc/soju/config
+state   : /var/lib/soju/main.db             (sqlite: users, networks, channels)
+          /var/lib/soju/logs/               (message history / backlog)
+listens : ircs:// on :6697  (your clients connect here, over TLS)
+```
+
+Data model:  **user** (login to soju) → **networks** (e.g. `libera`) → **channels**.
+
+**Access:** SSH in as your own user, not root. Set `LILBEE_HOST=user@host` in a private
+(un-versioned) file and `ssh "$LILBEE_HOST"`. That user has scoped passwordless sudo for
+`systemctl` and `sojuctl` only, and is in the `adm`/`systemd-journal` groups (read `journalctl`)
+and the `limnoria` group (read the bot's logs). So: prefix `systemctl restart` / `sojuctl` with
+**`sudo`**; plain `systemctl status`, `journalctl`, and log tails need no sudo.
+
+## Three ways to manage it
+
+### 1. systemd — the service itself
+```sh
+systemctl status soju          # running? since when?
+systemctl restart soju         # restart the bouncer
+systemctl stop soju            # take it offline
+journalctl -u soju -f          # live service logs (connections, errors)
+```
+
+### 2. sojuctl — admin CLI on the box (talks to soju's admin socket)
+```sh
+# accounts
+sojuctl user status                         # list soju accounts
+sojuctl user create -username X -password Y -admin
+sojuctl user update <user> -password Z      # change/tweak an account
+sojuctl user delete <user>
+
+# per-user network / channel management (run admin cmds "as" a user)
+sojuctl user run <user> network status                 # networks + connected state + channels
+sojuctl user run <user> network update libera -enabled false   # disconnect from Libera
+sojuctl user run <user> network update libera -enabled true    # reconnect
+sojuctl user run <user> network create -addr ircs://... -name foo -nick <NICK>
+sojuctl user run <user> network delete -network foo
+sojuctl user run <user> certfp fingerprint -network libera     # show the cert fp
+sojuctl user run <user> sasl status -network libera            # how it authenticates
+```
+Note the CLI quirk: `certfp`/`sasl` take `-network <name>`; `network create/update/delete`
+take the name **positionally**.
+
+`sojudb change-password <user>` also works and edits the DB directly (soju can be running).
+
+### 3. BouncerServ — chat commands from weechat
+Once weechat is connected to soju, message the built-in `BouncerServ` service — same
+commands, run as chat:
+```irc
+/msg BouncerServ network status
+/msg BouncerServ network update libera -enabled false
+/msg BouncerServ help
+```
+Channels are managed just by using IRC normally: `/join #foo` / `/part #foo` — soju
+remembers what you're in and rejoins on reconnect.
+
+## Common tasks
+
+| Task | How |
+|------|-----|
+| Is it up / connected? | `systemctl status soju` + `sojuctl user run <user> network status` |
+| Restart after config change | edit `/etc/soju/config` → `systemctl restart soju` |
+| See why it disconnected | `journalctl -u soju --since "1 hour ago"` |
+| Reconnect a dropped network | `sojuctl user run <user> network update libera -enabled true` |
+| Read missed messages on disk | `/var/lib/soju/logs/<user>/libera/#lilbee/*` |
+| Change your soju password | `sojudb change-password <user>` (then update weechat sec.data.soju_pass) |
+| Add another IRC network | `sojuctl user run <user> network create -addr ircs://... -name <n> -nick <nick>` |
+| Rotate the Libera CertFP | `certfp generate` again → `/msg NickServ CERT ADD <new-fp>` → `CERT DEL <old-fp>` |
+
+## Backup (what to save)
+
+Everything soju needs is `/var/lib/soju/` (db + logs) and `/etc/soju/config`. Back those up
+and the bouncer is fully recreatable. Secrets (soju password) live in weechat's `sec.conf`,
+not here.
+
+## Upgrades
+
+`apt upgrade` handles the soju package. It's a native service, so no container rebuild —
+`systemctl restart soju` picks up a new binary automatically after the package upgrade.
+
+---
+
+# Managing the Limnoria bot (lilbee-bot)
+
+Runs as systemd service `lilbee-bot` on the box (CertFP auth, no password in config).
+
+Quick controls (from the helpers in `lilbee.zsh` / `Makefile`):
+```
+make restart-bot          # or: lilbee-bot-restart   (zsh)
+make bot-status
+make bot-log
+```
+Identify to command it (private message, NOT in-channel):
+```
+/msg lilbee-bot identify <soju-user> <owner-password>
+```
+
+## Limnoria gotchas we hit (so future-you doesn't)
+- **Config is rewritten on shutdown.** Editing `lilbee-bot.conf` while the bot runs and then
+  restarting LOSES your edit (the dying process writes its old in-memory config back). Always
+  **stop -> edit -> start**, or change settings via the bot's own `config` command over IRC.
+- **Plugins need explicit enables.** Listing them in `supybot.plugins:` isn't enough; each needs
+  `supybot.plugins.<Name>: True` or it won't load (symptom: bot joins but ignores every command,
+  DEBUG log shows `findCallbacksForArgs: []`). setup-limnoria.sh includes these.

--- a/irc/Makefile
+++ b/irc/Makefile
@@ -1,0 +1,20 @@
+# lilbee IRC service management.  make restart-bot | restart-soju | bot-log | ...
+#
+# Set your host privately (NOT committed):  export LILBEE_HOST=user@host
+# or per-invocation:                         make restart-bot HOST=user@host
+HOST ?= $(LILBEE_HOST)
+
+ifeq ($(strip $(HOST)),)
+$(error Set LILBEE_HOST=user@host in your environment, or pass HOST=user@host)
+endif
+
+USER := $(firstword $(subst @, ,$(HOST)))
+
+.PHONY: restart-bot restart-soju bot-status soju-status bot-log soju-log
+
+restart-bot:  ; ssh $(HOST) sudo systemctl restart lilbee-bot && echo "lilbee-bot restarted"
+restart-soju: ; ssh $(HOST) sudo systemctl restart soju && echo "soju restarted"
+bot-status:   ; ssh $(HOST) systemctl --no-pager status lilbee-bot
+soju-status:  ; ssh $(HOST) 'echo soju=$$(systemctl is-active soju); sudo sojuctl user run $(USER) network status'
+bot-log:      ; ssh $(HOST) tail -n 50 -f /var/lib/limnoria/logs/messages.log
+soju-log:     ; ssh $(HOST) journalctl -u soju -f

--- a/irc/README.md
+++ b/irc/README.md
@@ -1,0 +1,116 @@
+# #lilbee on Libera.Chat — reproducible setup
+
+Everything needed to recreate the `#lilbee` IRC channel, the **soju** bouncer that
+keeps it always-on, and the weechat client that connects to it.
+
+Secrets are **not** stored here — they're placeholders (`<...>`). Real values live in
+weechat's encrypted `sec.conf` (`/secure`), not in version control.
+
+```
+placeholders used below
+  <NICK>        Libera NickServ account / founder nick (e.g. NuclearEndorphin)
+  <EMAIL>       email for NickServ registration
+  <NS_PASS>     NickServ account password
+  <SERVER_IP>   the always-on box running soju
+  <SOJU_USER>   soju account username (your login on the box)
+  <SOJU_PASS>   soju account password (generated; stored in weechat sec.data.soju_pass)
+```
+
+---
+
+## Part 1 — Libera channel (one-time, from any IRC client)
+
+Connect to `irc.libera.chat/6697` over TLS as `<NICK>`, then:
+
+```irc
+# register + verify the account (Libera emails a code)
+/msg NickServ REGISTER <NS_PASS> <EMAIL>
+/msg NickServ VERIFY REGISTER <NICK> <code-from-email>
+
+# register the channel (you become founder)
+/join #lilbee
+/msg ChanServ REGISTER #lilbee
+
+# harden it
+/msg ChanServ OP #lilbee <NICK>
+/msg ChanServ SET #lilbee GUARD ON        # ChanServ stays resident, protects modes
+/msg ChanServ SET #lilbee SECURE ON       # only services-verified users get access
+/msg ChanServ SET #lilbee KEEPTOPIC ON    # topic survives an empty channel
+/mode #lilbee +c                          # strip mIRC colours
+/mode #lilbee -s                          # discoverable via /LIST + ALIS
+/msg ChanServ FLAGS #lilbee <NICK> +O     # auto-op founder on every join
+/topic lilbee - a local search engine you can talk to. Runs on your machine, on demand. Site: https://lilbee.sh | Obsidian plugin: https://obsidian.lilbee.sh
+```
+
+Libera facts worth knowing: `NICKLEN=16` (max nick length), single-`#` channels are for
+projects you own, `##` is for unofficial/about-topic.
+
+---
+
+## Part 2 — soju bouncer (on the always-on box)
+
+Run `setup-soju.sh` on the server (Ubuntu 24.04). It installs soju, creates your account,
+and adds the Libera network **disabled** so it doesn't connect yet (avoids a nick clash
+with a client that's already on as `<NICK>`).
+
+```sh
+sudo ./setup-soju.sh <SOJU_USER> <NICK>
+# it prints the generated <SOJU_PASS> and the SHA-512 CertFP fingerprint
+```
+
+---
+
+## Part 3 — link soju to Libera via CertFP (no password stored)
+
+`setup-soju.sh` generated a client cert for the `libera` network and printed its
+**SHA-512** fingerprint. Libera requires SHA2-512 (not SHA-256).
+
+From a client that's **currently identified** as `<NICK>` on Libera (e.g. your existing
+direct weechat connection), authorize that fingerprint:
+
+```irc
+/msg NickServ CERT ADD <sha512-fingerprint>
+```
+
+Then enable the soju network so it connects via SASL EXTERNAL (CertFP):
+
+```sh
+sudo sojuctl user run <SOJU_USER> network update libera -enabled true
+sudo sojuctl user run <SOJU_USER> network status      # -> [connected]
+```
+
+---
+
+## Part 4 — point weechat at soju
+
+soju becomes the middleman: **weechat → soju → Libera**. The `username/network` form
+binds the connection straight to the libera network.
+
+```irc
+/server add lilbee <SERVER_IP>/6697 -tls
+/set irc.server.lilbee.tls_verify off                 # soju ships a self-signed cert
+/set irc.server.lilbee.sasl_mechanism plain
+/set irc.server.lilbee.sasl_username "<SOJU_USER>/libera"
+/secure set soju_pass <SOJU_PASS>
+/set irc.server.lilbee.sasl_password "${sec.data.soju_pass}"
+/set irc.server.lilbee.autojoin ""                    # soju remembers joined channels
+/connect lilbee
+/join #lilbee
+```
+
+You should land in `#lilbee` as `<NICK>`, founder-opped, with `CHATHISTORY` backlog replay
+(soju replays what you missed while disconnected — the whole point of the bouncer).
+
+---
+
+## Gotchas (learned the hard way)
+
+- Libera CertFP fingerprints must be **SHA-512** (128 hex chars). SHA-256 is rejected.
+- soju's `certfp`/`sasl` subcommands take `-network <name>`; `network create/update` take the
+  name **positionally**. Inconsistent, but that's the CLI.
+- soju's default TLS listener uses the snakeoil self-signed cert, so the client needs
+  `tls_verify off` (or install a real cert for an `irc.` subdomain).
+- Connecting with just `<SOJU_USER>` lands on soju's multi-network bouncer connection where
+  you can't `/join`. Use `<SOJU_USER>/libera` to bind to one network.
+- Only one connection can hold nick `<NICK>` at a time — disconnect any direct client before
+  enabling soju's network, or create the network `-enabled false` first (as the script does).

--- a/irc/lilbee.zsh
+++ b/irc/lilbee.zsh
@@ -1,0 +1,23 @@
+# lilbee IRC service helpers -- restart/inspect soju + the moderation bot on the box.
+# Safe to source unconditionally; set LILBEE_HOST when you want to use them.
+#
+#   source ~/projects/dotfiles/irc/lilbee.zsh          # in ~/.zshrc
+#   export LILBEE_HOST=user@host                        # in a PRIVATE, un-versioned file
+#
+_lilbee_host() {
+  [[ -n "$LILBEE_HOST" ]] && return 0
+  echo "lilbee: set LILBEE_HOST=user@host (e.g. in ~/.zshenv.local) first" >&2
+  return 1
+}
+
+lilbee-bot-restart()  { _lilbee_host || return; ssh "$LILBEE_HOST" sudo systemctl restart lilbee-bot && echo "lilbee-bot restarted"; }
+lilbee-bot-status()   { _lilbee_host || return; ssh "$LILBEE_HOST" systemctl --no-pager status lilbee-bot; }
+lilbee-bot-log()      { _lilbee_host || return; ssh "$LILBEE_HOST" tail -n 50 -f /var/lib/limnoria/logs/messages.log; }
+
+lilbee-soju-restart() { _lilbee_host || return; ssh "$LILBEE_HOST" sudo systemctl restart soju && echo "soju restarted"; }
+lilbee-soju-status()  { _lilbee_host || return; local u="${LILBEE_HOST%%@*}"; ssh "$LILBEE_HOST" "echo soju=\$(systemctl is-active soju); sudo sojuctl user run $u network status"; }
+lilbee-soju-log()     { _lilbee_host || return; ssh "$LILBEE_HOST" journalctl -u soju -f; }
+
+# short aliases
+alias lbbot='lilbee-bot-restart'
+alias lbsoju='lilbee-soju-restart'

--- a/irc/rotate-secrets.sh
+++ b/irc/rotate-secrets.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Regenerate (rotate) all generated lilbee IRC secrets. Run on the server as root.
+# New values are written ONLY to a root-only file; nothing is printed.
+#
+#   soju account password        -> update weechat sec.data.soju_pass afterwards
+#   lilbee-bot owner password    -> save in your password manager
+#   lilbee-bot NickServ recovery -> save in your password manager (bot connects via CertFP)
+#
+# Usage:  sudo ./rotate-secrets.sh [soju_user] [bot_nick]
+set -uo pipefail
+SOJU_USER="${1:?usage: rotate-secrets.sh <soju_user> [bot_nick]}"
+BOT="${2:-lilbee-bot}"
+DIR=/var/lib/limnoria
+OUT=/root/lilbee-new-secrets.txt
+umask 077; : > "$OUT"
+gen(){ openssl rand -base64 24 | tr -d '/+=' | cut -c1-24; }
+
+# 1) soju account password
+NEW_SOJU=$(gen)
+sojuctl user update "$SOJU_USER" -password "$NEW_SOJU" >/dev/null 2>&1 && S1=ok || S1=FAILED
+{ echo "[soju] '$SOJU_USER' NEW password: $NEW_SOJU"
+  echo "  weechat:  /secure set soju_pass $NEW_SOJU  ;  /reconnect lilbee   (status:$S1)"; echo; } >> "$OUT"
+
+systemctl stop "$BOT"; sleep 2
+
+# 2) bot owner password (fresh users db)
+NEW_OWNER=$(gen)
+rm -f "$DIR/conf/users.conf"
+(cd "$DIR" && sudo -u limnoria env HOME="$DIR" supybot-adduser -u "$SOJU_USER" -p "$NEW_OWNER" -c owner "$DIR/conf/users.conf") >/dev/null 2>&1 && S2=ok || S2=FAILED
+chown -R limnoria:limnoria "$DIR/conf"
+{ echo "[$BOT owner] '$SOJU_USER' NEW password: $NEW_OWNER"
+  echo "  identify: /msg $BOT identify $SOJU_USER $NEW_OWNER   (status:$S2)"; echo; } >> "$OUT"
+
+# 3) bot NickServ recovery password (via SASL EXTERNAL / CertFP -- Libera requires SASL from VPS IPs)
+NEW_BOTNS=$(gen)
+cat > /tmp/rot.py <<'PY'
+import socket,ssl,os,time
+NEW=os.environ["NEW_BOTNS"]; PEM=os.environ["PEM"]; NICK=os.environ["NICK"]
+ctx=ssl.create_default_context(); ctx.load_cert_chain(PEM)
+s=ctx.wrap_socket(socket.create_connection(("irc.libera.chat",6697),timeout=20),server_hostname="irc.libera.chat"); s.settimeout(4)
+snd=lambda l: s.sendall((l+"\r\n").encode())
+snd("CAP LS 302"); snd(f"NICK {NICK}"); snd(f"USER {NICK} 0 * :bot")
+buf="";ok=False;ident=False;dl=time.time()+25
+while time.time()<dl:
+    try:d=s.recv(4096).decode("utf-8","replace")
+    except:d=""
+    buf+=d
+    while "\r\n" in buf:
+        line,buf=buf.split("\r\n",1); low=line.lower(); p=line.split(" ")
+        if line.startswith("PING"): snd("PONG "+line.split(" ",1)[1]); continue
+        if " cap " in low and " ls " in low: snd("CAP REQ :sasl")
+        elif " cap " in low and " ack " in low and "sasl" in low: snd("AUTHENTICATE EXTERNAL")
+        elif line.rstrip().endswith("AUTHENTICATE +"): snd("AUTHENTICATE +")
+        elif len(p)>1 and p[1]=="903": snd("CAP END")
+        elif len(p)>1 and p[1]=="001" and not ident:
+            ident=True; time.sleep(1); snd("PRIVMSG NickServ :SET PASSWORD "+NEW)
+        if "nickserv" in low and "password" in low and ("changed" in low or "successfully" in low): ok=True
+snd("QUIT"); time.sleep(0.3); s.close(); print("ok" if ok else "UNCONFIRMED")
+PY
+S3=$(NEW_BOTNS="$NEW_BOTNS" PEM="$DIR/$BOT.pem" NICK="$BOT" python3 /tmp/rot.py 2>&1 | tail -1); rm -f /tmp/rot.py
+{ echo "[$BOT NickServ] recovery password: $NEW_BOTNS   (status:$S3)"; echo; } >> "$OUT"
+
+systemctl start "$BOT"; systemctl restart soju
+{ echo "== read this, apply the weechat change, save the rest, then: rm $OUT =="; } >> "$OUT"
+chmod 600 "$OUT"
+echo "ROTATION DONE (no secrets printed). New values -> $OUT  [soju:$S1 owner:$S2 botns:$S3]"

--- a/irc/setup-limnoria.sh
+++ b/irc/setup-limnoria.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Deploy Limnoria (the #lilbee moderation bot) as a systemd service on Ubuntu 24.04.
+# Auth to Libera via CertFP (SASL EXTERNAL) -> NO password in the config.
+#
+# Prereqs (do first, see libera-project-registration.md style flow):
+#   1. Register + verify the bot's NickServ account (e.g. lilbee-bot).
+#   2. You'll add the cert fingerprint this script prints to that account.
+#
+# Usage:  sudo ./setup-limnoria.sh <bot_nick>
+set -euo pipefail
+BOT="${1:?usage: setup-limnoria.sh <bot_nick>}"
+DIR=/var/lib/limnoria
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -q
+apt-get install -y limnoria
+id limnoria &>/dev/null || useradd -r -m -d "$DIR" -s /usr/sbin/nologin limnoria
+mkdir -p "$DIR"/{data,conf,logs,backup,plugins}
+
+# CertFP client cert (no password auth)
+cd "$DIR"
+openssl req -x509 -newkey rsa:2048 -keyout "$BOT.key" -out "$BOT.crt" -days 3650 -nodes -subj "/CN=$BOT" 2>/dev/null
+cat "$BOT.crt" "$BOT.key" > "$BOT.pem"; chmod 600 "$BOT.key" "$BOT.pem"
+FP=$(openssl x509 -noout -fingerprint -sha512 -in "$BOT.crt" | sed 's/.*=//; s/://g' | tr 'A-F' 'a-f')
+
+# Bot config (CertFP; realname marks it a bot + its admin, per Libera rules)
+cat > "$DIR/$BOT.conf" <<CONF
+supybot.nick: $BOT
+supybot.ident: ${BOT//-/}
+supybot.user: lilbee moderation bot - run by NuclearEndorphin | https://lilbee.sh
+supybot.networks: libera
+supybot.networks.libera.servers: irc.libera.chat:6697
+supybot.networks.libera.ssl: True
+supybot.networks.libera.channels: #lilbee
+supybot.networks.libera.certfile: $DIR/$BOT.pem
+supybot.networks.libera.sasl.username: $BOT
+supybot.networks.libera.sasl.mechanisms: external
+supybot.directories.data: $DIR/data
+supybot.directories.conf: $DIR/conf
+supybot.directories.log: $DIR/logs
+supybot.directories.backup: $DIR/backup
+supybot.directories.plugins: $DIR/plugins
+supybot.databases.users.allowUnregistration: True
+supybot.plugins: Owner User Config Admin Channel Misc Services Utilities Seen
+supybot.plugins.Owner: True
+supybot.plugins.User: True
+supybot.plugins.Config: True
+supybot.plugins.Admin: True
+supybot.plugins.Channel: True
+supybot.plugins.Misc: True
+supybot.plugins.Services: True
+supybot.plugins.Utilities: True
+supybot.plugins.Seen: True
+supybot.plugins.Services.NickServ: NickServ
+supybot.plugins.Services.ChanServ: ChanServ
+supybot.reply.whenAddressedBy.chars: !
+supybot.log.stdout: False
+CONF
+
+# systemd unit
+cat > /etc/systemd/system/$BOT.service <<UNIT
+[Unit]
+Description=Limnoria IRC bot ($BOT) for #lilbee
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=simple
+User=limnoria
+Group=limnoria
+WorkingDirectory=$DIR
+ExecStart=/usr/bin/limnoria $DIR/$BOT.conf
+Restart=on-failure
+RestartSec=10
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+chown -R limnoria:limnoria "$DIR"
+systemctl daemon-reload
+
+cat <<EOF
+
+======================================================================
+ Limnoria configured for $BOT (CertFP, no password in config).
+----------------------------------------------------------------------
+ BEFORE starting, authorize the cert on the bot's NickServ account:
+   (identify as $BOT with its recovery password, then)
+   /msg NickServ CERT ADD $FP     <-- Libera requires SHA-512
+
+ Then start it:
+   sudo systemctl enable --now $BOT
+
+ Give it channel op (from the channel founder's client):
+   /msg ChanServ FLAGS #lilbee $BOT +Oo
+
+ Add a bot owner so you can command it:
+   sudo -u limnoria env HOME=$DIR supybot-adduser -u <you> -p <pw> -c owner $DIR/conf/users.conf
+   then in IRC:  /msg $BOT identify <you> <pw>
+======================================================================
+EOF

--- a/irc/setup-soju.sh
+++ b/irc/setup-soju.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Install + configure soju as a systemd service (NOT docker) on Ubuntu 24.04.
+# soju is a single Go binary; it runs under systemd, stores state in
+# /var/lib/soju/ (sqlite db + message logs) and reads /etc/soju/config.
+#
+# Usage:  sudo ./setup-soju.sh <soju_user> <libera_nick>
+set -euo pipefail
+
+SOJU_USER="${1:?usage: setup-soju.sh <soju_user> <libera_nick>}"
+NICK="${2:?usage: setup-soju.sh <soju_user> <libera_nick>}"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -q
+apt-get install -y soju
+systemctl enable --now soju
+
+# soju account (what your IRC client logs into). Password is generated, not stored here.
+SOJU_PASS="$(openssl rand -base64 15 | tr -d '/+=' | cut -c1-18)"
+sojuctl user create -username "$SOJU_USER" -password "$SOJU_PASS" -admin
+
+# Add the Libera network DISABLED, so it doesn't connect yet (avoids a nick clash with a
+# client already on Libera as $NICK). We enable it after CertFP is authorized.
+sojuctl user run "$SOJU_USER" network create \
+  -addr ircs://irc.libera.chat:6697 -name libera \
+  -nick "$NICK" -realname "$NICK" -enabled false
+
+# Generate the CertFP client cert for the libera network + read its SHA-512 fingerprint.
+sojuctl user run "$SOJU_USER" certfp generate -network libera >/dev/null
+FP="$(sojuctl user run "$SOJU_USER" certfp fingerprint -network libera | awk '/SHA-512/{print $NF}')"
+
+cat <<EOF
+
+======================================================================
+ soju installed + configured  (systemd service 'soju', NOT docker)
+----------------------------------------------------------------------
+ soju login : $SOJU_USER
+ soju pass  : $SOJU_PASS      <-- SAVE THIS (goes in weechat sec.data.soju_pass)
+ Libera nick: $NICK  (network 'libera' created, currently DISABLED)
+
+ NEXT STEPS:
+ 1. From an IRC client identified as $NICK on Libera, authorize the cert:
+      /msg NickServ CERT ADD $FP
+ 2. Enable the network so soju connects via CertFP:
+      sudo sojuctl user run $SOJU_USER network update libera -enabled true
+ 3. Point your IRC client at this box: <SERVER_IP>/6697, tls, tls_verify off,
+    SASL PLAIN user "$SOJU_USER/libera", pass = the soju pass above.
+======================================================================
+EOF


### PR DESCRIPTION
Adds an `irc/` package with everything to stand up and run the #lilbee IRC presence:

- `setup-soju.sh` / `setup-limnoria.sh` — reproducible deploy of the soju bouncer and the Limnoria moderation bot, both authenticating to Libera via CertFP (no passwords stored).
- `rotate-secrets.sh` — regenerates all generated secrets server-side into a root-only file; nothing is printed.
- `lilbee.zsh` / `Makefile` — restart/log/status helpers. The SSH target comes from a private `LILBEE_HOST` env var, so no host or username is committed.
- `libera-project-registration.md` — drafts for registering lilbee as an official Libera project.
- `README.md` / `MANAGING.md` — setup walkthrough and operations guide, including the gotchas hit along the way (Limnoria's per-plugin enables, config-rewrite-on-shutdown, Libera SHA-512 CertFP).

No secrets, and no personal username/host, are committed.